### PR TITLE
Don't generate invalid class names

### DIFF
--- a/lib/name-generators.js
+++ b/lib/name-generators.js
@@ -3,7 +3,7 @@
 var emojiList = require('./emoji-list-compiled.js');
 function* genName() {
   const DIGITS = 'abcdefghijklmnopqrstuvwxyz1234567890-_';
-  const filterPattern = /ad/;
+  const filterPattern = /^(\d|--|-\d)/;
   let i = 0;
   let num = 0;
   while (true) {


### PR DESCRIPTION
https://www.w3.org/TR/CSS22/syndata.html#characters

Specifically, classes starting with numbers were being generated.