### PR TITLE
Fixes #8 Unnecessary whitespace when removing classes that do not match those defined in stylesheet

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -56,6 +56,7 @@ class MinifyClassnames {
               return this.classMap[value] || '';
             }
           })
+          .filter(Boolean)
           .join(' ')
           .trim();
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "posthtml-minify-classnames",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "PostHTML plugin for minifying classnames",
   "main": "index.js",
   "author": "Simon Laroche <hi@simon.lc> (https://simon.lc)",

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -684,3 +684,42 @@ test('works with no options', t => {
       t.is(result.html, expected);
     });
 });
+
+test('strips unnecessary whitespaces when removing classes that do not match any in our CSS #8', t => {
+  const html = `
+  <html>
+    <style>
+      .intro {
+        color: blue;
+      }
+      .big {
+        font-size: 600px;
+      }
+    </style>
+    <body>
+      <h1 class="intro non-existing-class big">Look!</h1>
+    </body>
+  </html>
+  `;
+
+  const expected = `
+  <html>
+    <style>
+      .a {
+        color: blue;
+      }
+      .b {
+        font-size: 600px;
+      }
+    </style>
+    <body>
+      <h1 class="a b">Look!</h1>
+    </body>
+  </html>
+  `;
+
+  return posthtml().use(plugin()).process(html)
+      .then(result => {
+        t.is(result.html, expected);
+      });
+});


### PR DESCRIPTION
See test case. There is a case when removing unused class name produces unnecessary whitespace. This fixes issue #8 